### PR TITLE
fix: added device_ids to webhook model (#16)

### DIFF
--- a/app/controllers/api/v1/users/webhooks_controller.rb
+++ b/app/controllers/api/v1/users/webhooks_controller.rb
@@ -16,6 +16,15 @@ module Api::V1
       render json: @webhooks
     end
 
+    def show
+      # grab just the webhooks under this stream_id
+      # the device_ids will only contain this stream_id
+      # probably useless endpoint, KIV
+      @webhooks = get_webhook_with_device_ids([params[:stream_id]]);
+
+      render json: @webhooks
+    end
+
     def create
       @webhook = Webhook.new(webhook_params)
 
@@ -87,7 +96,15 @@ module Api::V1
     end
 
     def get_webhook_with_device_ids(device_ids)
-      Webhook.includes(:devices).where("devices.id": device_ids).references(:devices)
+      # the webhooks returned won't contain any device_id as before
+      webhooks = Webhook.includes(:devices).where("devices.id": device_ids).references(:devices)
+
+      # append device_ids manually and return
+      webhook_arr = webhooks.to_a
+      webhooks.each_with_index do |w, i|
+        webhook_arr[i][:device_ids] = w.devices.ids
+      end
+      webhooks
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,8 @@ Rails.application.routes.draw do
             get 'read_only', to: 'access_tokens/read_only#index'
           end
           resources :streams, only: [:index, :create, :show, :update] do
-            resources :webhooks, only: [:destroy]  
+            resources :webhooks, only: [:destroy]
+            get 'webhooks', to: 'webhooks#show'
           end
           resources :webhooks, only: [:index, :create, :update]
         end

--- a/db/migrate/20190310144133_add_device_ids_to_webhooks.rb
+++ b/db/migrate/20190310144133_add_device_ids_to_webhooks.rb
@@ -1,0 +1,5 @@
+class AddDeviceIdsToWebhooks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :webhooks, :device_ids, :integer, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_06_142631) do
+ActiveRecord::Schema.define(version: 2019_03_10_144133) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,6 +96,7 @@ ActiveRecord::Schema.define(version: 2019_03_06_142631) do
     t.json "http_headers", default: [], array: true
     t.string "method"
     t.string "name"
+    t.integer "device_ids", default: [], array: true
   end
 
   add_foreign_key "access_tokens", "users"


### PR DESCRIPTION
added device_ids to webhook model
this is to send the device_ids values for each webhook when returning as JSON from GET routes

also added a 'show' route to get webhooks under ONE stream_id, but most probably not useful, KIV first.