### PR TITLE
Feat/modification web executor #15

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'rack-cors', require: 'rack/cors'
 
 gem 'will_paginate'
 gem 'devise'
+gem 'rest-client'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,10 +60,14 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.8.0)
     ffi (1.10.0-java)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     i18n (1.5.3)
       concurrent-ruby (~> 1.0)
     jdbc-postgres (42.1.4)
@@ -79,9 +83,13 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
     mimemagic (0.3.3)
     mini_mime (1.0.1)
     minitest (5.11.3)
+    netrc (0.11.0)
     nio4r (2.3.1-java)
     nokogiri (1.10.1-java)
     orm_adapter (0.5.0)
@@ -125,6 +133,10 @@ GEM
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
       railties (>= 4.2.0, < 6.0)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -162,6 +174,7 @@ GEM
       thread_safe (~> 0.1)
     tzinfo-data (1.2018.9)
       tzinfo (>= 1.0.0)
+    unf (0.1.4-java)
     warden (1.2.8)
       rack (>= 2.0.6)
     websocket-driver (0.7.0-java)
@@ -180,6 +193,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rack-cors
   rails (~> 5.2.2)
+  rest-client
   rspec
   rspec-rails
   tzinfo-data

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -3,7 +3,8 @@ class Device < ActiveRecord::Base
   has_many :device_access_tokens, dependent: :destroy
   has_many :log_data, dependent: :destroy
   has_many :device_webhooks, dependent: :destroy
-  has_many :webhooks, -> { distinct }, through: :device_webhooks
+  # cannot do distinct on webhooks due to PSQL inequality error on json
+  has_many :webhooks, through: :device_webhooks
 
   validates :uuid, presence: true, uniqueness: true
 

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -4,6 +4,7 @@ class Device < ActiveRecord::Base
   has_many :log_data, dependent: :destroy
   has_many :device_webhooks, dependent: :destroy
   # cannot do distinct on webhooks due to PSQL inequality error on json
+  # every webhook under a device in device_webhooks should be unique due to unique name
   has_many :webhooks, through: :device_webhooks
 
   validates :uuid, presence: true, uniqueness: true

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -3,6 +3,6 @@ class Webhook < ActiveRecord::Base
   has_many :devices, -> { distinct }, through: :device_webhooks
 
   validates :name, presence: true, uniqueness: true, length: { minimum: 3, maximum: 25}
-  validates :url, presence: true, format: { with: /\A(https:\/\/)(www\.){0,1}[a-zA-Z0-9\.\-]+\.[a-zA-Z]{2,5}[\.]{0,1}\z/, on: :create }
+  validates :url, presence: true, format: { with: /\A(https:\/\/)((www\.){0,1}[a-zA-Z0-9\.\-]+\.[a-zA-Z]{2,5}[\.]{0,1}|localhost)(.*)\z/, on: :create }
   validates :devices, presence: true
 end


### PR DESCRIPTION
- added secret based on webhook header
- RestClient able to send with different method according to webhook header
- removed distinct constraint for webhooks in device model (a device should not have duplicate webhooks to begin with)
- updated url regex format validation